### PR TITLE
Allow configuring the email envelope

### DIFF
--- a/lib/malone.rb
+++ b/lib/malone.rb
@@ -30,6 +30,7 @@ class Malone
 
   def deliver(dict)
     mail = envelope(dict)
+    yield mail if block_given?
 
     smtp = Net::SMTP.new(config.host, config.port)
     smtp.enable_starttls_auto if config.tls

--- a/test/malone.rb
+++ b/test/malone.rb
@@ -186,6 +186,15 @@ scope do
     assert $smtp[:finish]
   end
 
+  test "adding custom headers" do |m|
+    m.deliver(to: "recipient@me.com", from: "no-reply@mydomain.com",
+              subject: "Happy new year!", text: "TEXT") do |mail|
+      mail.add_header("X-MC-SendAt", "2016-01-01 00:00:00")
+    end
+
+    assert $smtp[:blob].include?("X-MC-SendAt: 2016-01-01 00:00:00")
+  end
+
   test "calls #finish even when it fails during send_message" do |m|
     class FakeSMTP
       def send_message(*args)


### PR DESCRIPTION
I needed to add custom headers, and figured this is the cleanest way of exposing the Kuvert envelope object thingy.

Another possibility is checking if `dict` is an envelope already or not, and then let people do something like:

``` ruby
mail = malone.envelope(...)
mail.add_header(...)
malone.deliver(mail)
```

But it seems much more noisy than yielding the envelope ¯\\\_(ツ)\_/¯

What do you think @cyx?